### PR TITLE
add convenience methods and expose Reflex.UI

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,18 @@
+{ mkDerivation, aeson, base, containers, lens, reflex, reflex-dom
+, stdenv, text
+}:
+mkDerivation {
+  pname = "reflex-ui";
+  version = "0.1.0.0";
+  src = ./.;
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    aeson base containers lens reflex reflex-dom text
+  ];
+  executableHaskellDepends = [
+    aeson base lens reflex reflex-dom text
+  ];
+  description = "A UI framework for Reflex built on top of the Bulma CSS framework";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/reflex-ui.cabal
+++ b/reflex-ui.cabal
@@ -16,7 +16,8 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 library
-  exposed-modules:     Reflex.UI.Elements
+  exposed-modules:     Reflex.UI
+                     , Reflex.UI.Elements
                      , Reflex.UI.Layouts
   -- other-modules:       
   -- other-extensions:    

--- a/src/Reflex/UI.hs
+++ b/src/Reflex/UI.hs
@@ -1,0 +1,5 @@
+module Reflex.UI ( module X ) where
+
+import Reflex.UI.Elements as X
+import Reflex.UI.Layouts as X
+

--- a/src/Reflex/UI/Elements.hs
+++ b/src/Reflex/UI/Elements.hs
@@ -88,8 +88,8 @@ removeClass name attrs = attrs & at "class" . _Just %~ remove
 base :: Dom.DomBuilder t m => Attrs -> m a -> m a
 base = Dom.elAttr "base"
 
-head :: Dom.DomBuilder t m => Attrs -> m a -> m a
-head = Dom.elAttr "head"
+head' :: Dom.DomBuilder t m => Attrs -> m a -> m a
+head' = Dom.elAttr "head"
 
 link :: Dom.DomBuilder t m => Attrs -> m a -> m a
 link = Dom.elAttr "link"

--- a/src/Reflex/UI/Elements.hs
+++ b/src/Reflex/UI/Elements.hs
@@ -36,11 +36,11 @@ empty = return ()
 -- | Build an attribute value pair. This lets you write neater-looking
 -- elements:
 -- @
--- img ["src" =: "./logo.png", "alt" =: "Our lovely logo."] empty
+-- img ["src" ==: "./logo.png", "alt" ==: "Our lovely logo."] empty
 --   -- <img src="./logo.png" alt = "Our lovely logo."></img>
 -- @
-(=:) :: Text -> Text -> Attr
-attr =: value = (attr, value)
+(==:) :: Text -> Text -> Attr
+attr ==: value = (attr, value)
 
 -- | Adds the "enabled" attribute and removes the "disabled" attribute
 -- (if present).

--- a/src/Reflex/UI/Elements.hs
+++ b/src/Reflex/UI/Elements.hs
@@ -149,6 +149,14 @@ h5 = Dom.elAttr "h5"
 h6 :: Dom.DomBuilder t m => Attrs -> m a -> m a
 h6 = Dom.elAttr "h6"
 
+h1',h2',h3',h4',h5',h6' :: Dom.DomBuilder t m => Text -> m ()
+h1' = h1 mempty . Dom.text
+h2' = h2 mempty . Dom.text
+h3' = h3 mempty . Dom.text
+h4' = h4 mempty . Dom.text
+h5' = h5 mempty . Dom.text
+h6' = h6 mempty . Dom.text
+
 -- ** Text Content
 
 dd :: Dom.DomBuilder t m => Attrs -> m a -> m a
@@ -171,6 +179,9 @@ figure = Dom.elAttr "figure"
 
 hr :: Dom.DomBuilder t m => Attrs -> m a -> m a
 hr = Dom.elAttr "hr"
+
+hr' :: Dom.DomBuilder t m => m ()
+hr' = Dom.elAttr "hr" mempty Dom.blank
 
 li :: Dom.DomBuilder t m => Attrs -> m a -> m a
 li = Dom.elAttr "li"

--- a/src/Reflex/UI/Layouts.hs
+++ b/src/Reflex/UI/Layouts.hs
@@ -12,5 +12,5 @@ columns attrs = div' (addClass "columns" attrs)
 column :: Dom.DomBuilder t m => Attrs -> m a -> m a
 column attrs = div' (addClass "column" attrs)
 
-col :: Dom.DomBuilder t m => m a -> m a
-col = div' ["class" =: "column"]
+column' :: Dom.DomBuilder t m => m a -> m a
+column' = div' ["class" ==: "column"]


### PR DESCRIPTION
There is an implied pattern of <element>' meaning 'the simple version' (`h1' "Header Title"`) where it only takes the text input or nothing instead of `Attrs -> m a -> m a`. This seems "ok" at best. I'd be open to other suggestions. I also changed the infix tuple-maker `=:` to `==:` in order to avoid collisions with reflex-dom. I'm also not wedded to this because this will most likely be imported qualified, so it may not be an issue.